### PR TITLE
feat: implement certification endpoints

### DIFF
--- a/packages/service-discovery/api/certification.ts
+++ b/packages/service-discovery/api/certification.ts
@@ -1,0 +1,85 @@
+import { redis } from "../utils/redis";
+
+export const config = {
+  runtime: "edge",
+};
+
+interface RequestBody {
+  hash: string;
+  imageSignature: string;
+}
+
+function generateUUID(): string {
+  let uuid = '';
+  const randomValues = new Uint8Array(16);
+
+  // Generate random values
+  crypto.getRandomValues(randomValues);
+
+  // Set version and variant bits
+  randomValues[6] = (randomValues[6] & 0x0f) | 0x40;
+  randomValues[8] = (randomValues[8] & 0x3f) | 0x80;
+
+  // Convert to hexadecimal string
+  for (let i = 0; i < 16; i++) {
+    const value = randomValues[i];
+    uuid += value.toString(16).padStart(2, '0');
+  }
+
+  // Format the UUID string
+  uuid = uuid.slice(0, 8) + '-' + uuid.slice(8, 12) + '-' + uuid.slice(12, 16) + '-' + uuid.slice(16, 20) + '-' + uuid.slice(20);
+
+  return uuid;
+}
+
+export const GET = async (request: Request): Promise<Response> => {
+  try {
+    const url = new URL(request.url);
+    const searchParams = new URLSearchParams(url.search);
+
+    const hash = searchParams.get('hash');
+    const imageSignature = searchParams.get('imageSignature');
+
+    if (!hash || !imageSignature || typeof hash !== 'string' || typeof imageSignature !== 'string') {
+      return new Response("missing hash or image signature", { status: 400 });
+    }
+
+    const certificate = await redis.get<string>(`${imageSignature}:${hash}`);
+    if (certificate) {
+      return new Response(certificate, { status: 200 });
+    }
+
+    // a random UUID will be sent to cheating miners
+    return new Response(generateUUID());
+  } catch {
+    return new Response("Failure", { status: 400 });
+  }
+};
+
+export const PUT = async (request: Request) => {
+  try {
+    const authHeader = request.headers.get("Authorization");
+    const expectedAuthHeader = `Bearer ${process.env.SECRET_KEY}`;
+
+    if (!authHeader || authHeader !== expectedAuthHeader) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const body = await request.json();
+    const { hash, imageSignature } = body as RequestBody;
+
+    if (!hash || !imageSignature || typeof hash !== 'string' || typeof imageSignature !== 'string') {
+      return new Response("missing hash or image signature", { status: 400 });
+    }
+
+    const uuid = generateUUID();
+    const res = await redis.set(`${imageSignature}:${hash}`, uuid);
+
+    if (res === 'OK') {
+      return new Response('ok', { status: 200 });
+    }
+  } catch {
+    return new Response("Failure", { status: 400 });
+  } 
+  
+};

--- a/packages/service-discovery/api/miner.ts
+++ b/packages/service-discovery/api/miner.ts
@@ -1,9 +1,4 @@
-import { Redis } from "@upstash/redis";
-
-const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_REST_URL!,
-  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
-});
+import { redis } from "../utils/redis";
 
 export const config = {
   runtime: "edge",

--- a/packages/service-discovery/package.json
+++ b/packages/service-discovery/package.json
@@ -3,6 +3,7 @@
   "description": "This is an internal API mapping what services are available at which address in the network.",
   "module": "NodeNext",
   "dependencies": {
-    "@upstash/redis": "^1.29.0"
+    "@upstash/redis": "^1.29.0",
+    "zod": "^3.23.6"
   }
 }

--- a/packages/service-discovery/utils/redis.ts
+++ b/packages/service-discovery/utils/redis.ts
@@ -1,0 +1,6 @@
+import { Redis } from "@upstash/redis";
+
+export const redis = new Redis({
+  url: process.env.UPSTASH_REDIS_REST_URL!,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});


### PR DESCRIPTION
<!-- Please follow this pattern for generating pull requests -->

## Description of the pull request

The subnet's focus is on edge delivery of AI at scale. We are implementing a certification mechanisms for the miners to ensure they are running approved images in the subnet. This will ensure  nobody is trying to game the system. This security will have multiple facets. Rotating certification keys is one of them. The scenario goes like this:

1. A miner downloads a signed certified docker image and runs it
2. The docker image will show a checksum hash of itself proving it's identity.
3. The certification api will return a private value associated with this image to be included in API responses from miners
4. this certification will change at a random moment forcing miners to re authenticate


This PR includes is the API side of this flow.


## Changes made

<!-- Provide brief information about the changes made -->

1. move redis client into a common file to avoid code duplication
2. create a put and get endpoint for the certicicates. The put endpoint is bearer protected since only admins can update the certificate
3. create a get endpoint checking the validity of hash and image signature, returns the current rotating certificate

## Related issues

<!-- Provide the related issues that are being solved or addressed by this PR (if any) -->

## Testings done

<!-- Provide a happy path to test and reproduce this issue-->

## Screenshots (if any)

<!-- Provide the screenshots of the changes made and how it affects the project -->

## Checklist

- [ ] I have written tests
- [ ] My code does not produce new errors
- [ ] I gave myself a code review before asking others.
